### PR TITLE
Bug Fix: system appearance change does not change timer frame border color while the app is running in the background

### DIFF
--- a/MinimalTimer.xcodeproj/project.pbxproj
+++ b/MinimalTimer.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QZA35QY3B5;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -447,7 +447,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QZA35QY3B5;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/MinimalTimer.xcodeproj/project.pbxproj
+++ b/MinimalTimer.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.imhojang.minimaltimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -464,7 +464,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.imhojang.minimaltimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/MinimalTimer/UI/Timer/Subviews/TimerFrameView.swift
+++ b/MinimalTimer/UI/Timer/Subviews/TimerFrameView.swift
@@ -10,6 +10,10 @@ final class TimerFrameView: UIView {
     private let cornerRadius: CGFloat
     private let radius: CGFloat
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        layer.borderColor = Constant.borderColor.cgColor
+    }
     
     init(radius: CGFloat) {
         self.radius = radius


### PR DESCRIPTION
Fixed using `traitCollectionDidChange`  method.
However, as of iOS 17 this method has been deprecated. Should make corresponding update following the document page.

reference: https://developer.apple.com/documentation/uikit/uitraitenvironment/1623516-traitcollectiondidchange